### PR TITLE
Fix warning: Forming 'UnsafeRawPointer' to an inout variable of type String exposes the internal representation rather than the string contents.

### DIFF
--- a/Sources/FireworkVideoUI/AppLanguage/Extensions/UIKit/UILabel+AppLanguage.swift
+++ b/Sources/FireworkVideoUI/AppLanguage/Extensions/UIKit/UILabel+AppLanguage.swift
@@ -8,7 +8,7 @@ import UIKit
 
 extension UILabel {
     private struct AssociatedKeys {
-        static var hasCalculatedTextAlignment = "hasCalculatedTextAlignmentKey"
+        static var hasCalculatedTextAlignment: UInt8 = 0
     }
 
     private var hasCalculatedTextAlignment: Bool {

--- a/Sources/FireworkVideoUI/AppLanguage/Extensions/UIKit/UITextField+AppLanguage.swift
+++ b/Sources/FireworkVideoUI/AppLanguage/Extensions/UIKit/UITextField+AppLanguage.swift
@@ -8,7 +8,7 @@ import UIKit
 
 extension UITextField {
     private struct AssociatedKeys {
-        static var hasCalculatedTextAlignment = "hasCalculatedTextAlignmentKey"
+        static var hasCalculatedTextAlignment: UInt8 = 0
     }
 
     private var hasCalculatedTextAlignment: Bool {

--- a/Sources/FireworkVideoUI/AppLanguage/Extensions/UIKit/UITextView+AppLanguage.swift
+++ b/Sources/FireworkVideoUI/AppLanguage/Extensions/UIKit/UITextView+AppLanguage.swift
@@ -8,7 +8,7 @@ import UIKit
 
 extension UITextView {
     private struct AssociatedKeys {
-        static var hasCalculatedTextAlignment = "hasCalculatedTextAlignmentKey"
+        static var hasCalculatedTextAlignment: UInt8 = 0
     }
 
     private var hasCalculatedTextAlignment: Bool {

--- a/Sources/FireworkVideoUI/LayoutFlip/Extensions/Foundation/NSObject+LayoutFlip.swift
+++ b/Sources/FireworkVideoUI/LayoutFlip/Extensions/Foundation/NSObject+LayoutFlip.swift
@@ -10,7 +10,7 @@ typealias ReloadClosure = () -> Void
 
 extension NSObject {
     private struct AssociatedKeys {
-        static var reloadClosures = "reloadBlocks"
+        static var reloadClosures: UInt8 = 0
     }
 
     private var reloadClosures: [String: ReloadClosure] {

--- a/Sources/FireworkVideoUI/LayoutFlip/Extensions/UIKit/CALayer+LayoutFlip.swift
+++ b/Sources/FireworkVideoUI/LayoutFlip/Extensions/UIKit/CALayer+LayoutFlip.swift
@@ -8,9 +8,9 @@ import UIKit
 
 extension CALayer {
     private struct AssociatedKeys {
-        static var basicTransform = "basicTransform"
-        static var isRenderStartLayer = "isRenderStartLayer"
-        static var affineTransform = "affineTransform"
+        static var basicTransform: UInt8 = 0
+        static var isRenderStartLayer: UInt8 = 0
+        static var affineTransform: UInt8 = 0
     }
 
     static func swizzleLayerMethodsForLayoutFlip() {

--- a/Sources/FireworkVideoUI/LayoutFlip/Extensions/UIKit/UIView+LayoutFlip.swift
+++ b/Sources/FireworkVideoUI/LayoutFlip/Extensions/UIKit/UIView+LayoutFlip.swift
@@ -32,9 +32,9 @@ enum LayoutFlipViewType: Int {
 
 extension UIView {
     private struct AssociatedKeys {
-        static var viewType = "viewType"
-        static var calculatedViewType = "calculatedViewType"
-        static var lastType = "lastType"
+        static var viewType: UInt8 = 0
+        static var calculatedViewType: UInt8 = 0
+        static var lastType: UInt8 = 0
     }
 
     static func swizzleViewMethodsForLayoutFlip() {


### PR DESCRIPTION
## Objective :dart:
Ticket: [CPS-819](https://fwn.atlassian.net/browse/CPS-819)
  
## Changes :boom:
 - Fix warning: Forming 'UnsafeRawPointer' to an inout variable of type String exposes the internal representation rather than the string contents.

[CPS-819]: https://fwn.atlassian.net/browse/CPS-819?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ